### PR TITLE
Custom cell refactor

### DIFF
--- a/src/components/GigaRow/FrozenGigaRow.tsx
+++ b/src/components/GigaRow/FrozenGigaRow.tsx
@@ -1,17 +1,23 @@
 import * as React from "react";
 import {GigaRow} from "./GigaRow";
 import {Column} from "../../models/ColumnLike";
-import {Cell} from "../Cell";
+import {CellProps} from "../Cell";
 
+/**
+ * a row in the freeze pane section of the table
+ */
 export class FrozenGigaRow extends GigaRow {
-    mapColumnToCell(column:Column, i:number){
-        return (<Cell key={i}
-                      isFirstColumn={i === 0}
-                      column={column}
-                      columnNumber={i}
-                      rowHeight={this.props.rowHeight}
-                      dispatcher={this.props.dispatcher}
-                      gridProps={this.props.gridProps}
-                      row={this.props.row}/>)
-    }    
+    getCellProps(column: Column, i: number): CellProps {
+        let {rowHeight, dispatcher, gridProps, row} = this.props;
+        return {
+            key: i,
+            isFirstColumn: i === 0,
+            column: column,
+            columnNumber: i,
+            rowHeight: rowHeight,
+            dispatcher: dispatcher,
+            gridProps: gridProps,
+            row: row
+        }
+    }
 }

--- a/src/components/GigaRow/ScrollableGigaRow.tsx
+++ b/src/components/GigaRow/ScrollableGigaRow.tsx
@@ -1,17 +1,20 @@
 import * as React from "react";
 import {GigaRow} from "./GigaRow";
 import {Column} from "../../models/ColumnLike";
-import {Cell} from "../Cell";
+import {CellProps} from "../Cell";
 
 export class ScrollableGigaRow extends GigaRow {
-    mapColumnToCell(column:Column, i:number){
-        return (<Cell key={i}
-                      isFirstColumn={i == 0 && !this.props.gridProps.staticLeftHeaders}
-                      column={column}
-                      columnNumber={i + (this.props.gridProps.staticLeftHeaders || 0)}
-                      rowHeight={this.props.rowHeight}
-                      dispatcher={this.props.dispatcher}
-                      gridProps={this.props.gridProps}
-                      row={this.props.row}/>)
+    getCellProps(column: Column, i: number): CellProps {
+        let {gridProps, rowHeight, dispatcher, row} = this.props;
+        return {
+            key: i,
+            isFirstColumn: i == 0 && !gridProps.staticLeftHeaders,
+            column: column,
+            columnNumber: i + (gridProps.staticLeftHeaders || 0),
+            rowHeight: rowHeight,
+            dispatcher: dispatcher,
+            gridProps: gridProps,
+            row: row
+        }
     }
 }

--- a/src/components/TableBody/FrozenTableBody.tsx
+++ b/src/components/TableBody/FrozenTableBody.tsx
@@ -4,13 +4,17 @@ import {FrozenGigaRow} from "../GigaRow/FrozenGigaRow";
 import {TableBody} from "./TableBody";
 
 export class FrozenTableBody extends TableBody {
-    mapRowsInBody(rowHeight:number, row:Row, i:number):JSX.Element{
-        return (<FrozenGigaRow key={i}
-                               columns={this.props.columns}
-                               row={row}
-                               rowHeight={`${rowHeight}`}
-                               dispatcher={this.props.dispatcher}
-                               staticLeftHeaders={true}
-                               gridProps={this.props.gridProps}/>);
+    mapRowsInBody(rowHeight: number, row: Row, i: number): JSX.Element {
+        let {columns, dispatcher, gridProps} = this.props;
+        return (
+            <FrozenGigaRow key={i}
+                           columns={columns}
+                           row={row}
+                           rowHeight={`${rowHeight}`}
+                           dispatcher={dispatcher}
+                           staticLeftHeaders={true}
+                           gridProps={gridProps}
+            />
+        );
     }
 }

--- a/src/components/TableBody/ScrollableTableBody.tsx
+++ b/src/components/TableBody/ScrollableTableBody.tsx
@@ -4,13 +4,17 @@ import {Row} from "../../models/Row";
 import {ScrollableGigaRow} from "../GigaRow/ScrollableGigaRow";
 
 export class ScrollableTableBody extends TableBody {
-    mapRowsInBody(rowHeight:number, row:Row, i:number){
-        return (<ScrollableGigaRow key={i}
-                                   columns={this.props.columns}
-                                   row={row}
-                                   rowHeight={`${rowHeight}`}
-                                   dispatcher={this.props.dispatcher}
-                                   scrollableRightData={true}
-                                   gridProps={this.props.gridProps}/>);
+    mapRowsInBody(rowHeight: number, row: Row, i: number) {
+        let {columns, dispatcher, gridProps} = this.props;
+        return (
+            <ScrollableGigaRow key={i}
+                               columns={columns}
+                               row={row}
+                               rowHeight={`${rowHeight}`}
+                               dispatcher={dispatcher}
+                               scrollableRightData={true}
+                               gridProps={gridProps}
+            />
+        );
     }
 }

--- a/src/components/TableBody/TableBody.tsx
+++ b/src/components/TableBody/TableBody.tsx
@@ -14,31 +14,32 @@ export interface TableBodyProps extends GridComponentProps<TableBody> {
 
 export class TableBody extends React.Component<TableBodyProps,any> {
 
-    constructor(props:TableBodyProps) {
+    constructor(props: TableBodyProps) {
         super(props);
     }
 
-    private isProgressiveRenderingEnabled():boolean {
+    private isProgressiveRenderingEnabled(): boolean {
+        let {rows, displayStart, displayEnd, rowHeight} = this.props;
         return (
-            this.props.rows.length > PROGRESSIVE_RENDERING_THRESHOLD
-            && typeof this.props.displayStart !== "undefined"
-            && typeof this.props.displayEnd !== "undefined"
-            && typeof this.props.rowHeight !== this.props.rowHeight
+            rows.length > PROGRESSIVE_RENDERING_THRESHOLD
+            && typeof displayStart !== "undefined"
+            && typeof displayEnd !== "undefined"
+            && typeof rowHeight !== this.props.rowHeight
         );
     }
 
-    renderRows(rowHeight: number, start?:number, end?:number):JSX.Element[] {
+    renderRows(rowHeight: number, start?: number, end?: number): JSX.Element[] {
         const rows = validateBounds(start, end) ? this.props.rows.slice(start, end + 1) : this.props.rows;
-        return rows.map((row:Row, i:number) => this.mapRowsInBody(rowHeight, row, i));
+        return rows.map((row: Row, i: number) => this.mapRowsInBody(rowHeight, row, i));
     }
 
-    mapRowsInBody(rowHeight:number, row:Row, i:number):JSX.Element {
+    mapRowsInBody(rowHeight: number, row: Row, i: number): JSX.Element {
         throw "Must extend TableBody, cannot use is as a component directly!";
     }
 
     render() {
+        let {rowHeight, displayStart, displayEnd} = this.props;
         if (this.isProgressiveRenderingEnabled()) {
-
             /*
              we only render from displayStart -> displayEnd in rows
              we compute the theoretical height of elements between 0 -> displayStart
@@ -47,18 +48,20 @@ export class TableBody extends React.Component<TableBodyProps,any> {
 
              this allows us to preserve the total height of contents in table without actually rendering every row
              */
-            const rows = this.renderRows(parseInt(this.props.rowHeight), this.props.displayStart, this.props.displayEnd);
-            const placeholderHeights = this.calculatePlaceholderHeight();
+            let rows = this.renderRows(parseInt(rowHeight), displayStart, displayEnd);
+            let placeholderHeights = this.calculatePlaceholderHeight();
             return (
                 <div>
-                    <div style={{height: placeholderHeights.upperPlaceholderHeight + "px"}} className="placeholder"></div>
+                    <div style={{height: placeholderHeights.upperPlaceholderHeight + "px"}}
+                         className="placeholder"></div>
                     {rows}
-                    <div style={{height: placeholderHeights.lowerPlaceholderHeight + "px"}} className="placeholder"></div>
+                    <div style={{height: placeholderHeights.lowerPlaceholderHeight + "px"}}
+                         className="placeholder"></div>
                 </div>
             );
 
         } else {
-            const rows = this.renderRows(parseInt(this.props.rowHeight));
+            let rows = this.renderRows(parseInt(rowHeight));
             return (
                 <div>
                     {rows}
@@ -68,14 +71,15 @@ export class TableBody extends React.Component<TableBodyProps,any> {
     }
 
     private calculatePlaceholderHeight() {
-        const rowHeight:number = parseInt(this.props.rowHeight);
+        let {rowHeight, displayStart, displayEnd, rows} = this.props;
+        let rowHeightInt: number = parseInt(rowHeight);
         return {
-            upperPlaceholderHeight: Math.max(this.props.displayStart * rowHeight, 0),
-            lowerPlaceholderHeight: Math.max((this.props.rows.length - this.props.displayEnd) * rowHeight, 0)
+            upperPlaceholderHeight: Math.max(displayStart * rowHeightInt, 0),
+            lowerPlaceholderHeight: Math.max((rows.length - displayEnd) * rowHeightInt, 0)
         };
     }
 }
 
-function validateBounds(start:number, end:number):boolean {
+function validateBounds(start: number, end: number): boolean {
     return typeof start !== "undefined" && typeof end !== "undefined";
 }

--- a/src/components/TableHeader.tsx
+++ b/src/components/TableHeader.tsx
@@ -5,9 +5,9 @@ import {GridComponentProps, getScrollBarWidth} from "./GigaGrid";
 import Dispatcher = Flux.Dispatcher;
 
 export interface TableHeaderProps extends GridComponentProps<TableHeader> {
-    tableHeaderClass?:string
-    columns:Column[][]
-    staticLeftHeaders:number
+    tableHeaderClass?: string
+    columns: Column[][]
+    staticLeftHeaders: number
 }
 
 /**
@@ -18,7 +18,7 @@ export interface TableHeaderProps extends GridComponentProps<TableHeader> {
  */
 export class TableHeader extends React.Component<TableHeaderProps,any> {
 
-    constructor(props:TableHeaderProps) {
+    constructor(props: TableHeaderProps) {
         super(props);
     }
 
@@ -30,43 +30,50 @@ export class TableHeader extends React.Component<TableHeaderProps,any> {
         )
     }
 
-    private renderHeaderRows():JSX.Element[] {
-        const trs:JSX.Element[] = [];
-        var i:number;
+    private renderHeaderRows(): JSX.Element[] {
+        const trs: JSX.Element[] = [];
+        var i: number;
         for (i = 0; i < this.props.columns.length - 1; i++)
             trs.push(TableHeader.renderColumnGroups(this.props.columns[i], i));
         trs.push(this.renderLeafColumns(this.props.columns[i], i));
         return trs;
     }
 
-    private static renderColumnGroups(columns:Column[], key:number):JSX.Element {
-        const ths = columns.map((column:Column, i:number)=> {
-            const style:any = {
+    private static renderColumnGroups(columns: Column[], key: number): JSX.Element {
+        const ths = columns.map((column: Column, i: number)=> {
+            const style: any = {
                 width: column.colSpan + "px"
             };
             return (
-                <div className="column-group" key={i} style={style}><span className="content header-text">{column.title}</span></div>
+                <div className="column-group" key={i} style={style}>
+                    <span className="content header-text">{column.title}</span>
+                </div>
             );
         });
         return (<div className="column-group-row" key={key}>{ths}</div>);
     }
 
-    private renderLeafColumns(columns:Column[], key:number):JSX.Element {
-        const ths = columns.map((column:Column, i:number)=> {
-            return <TableHeaderCell column={column} key={i}
-                                    isFirstColumn={i===0}
-                                    isLastColumn={i===columns.length-1}
-                                    columnNumber={i}
-                                    tableHeaderClass={this.props.tableHeaderClass}
-                                    gridProps={this.props.gridProps}
-                                    dispatcher={this.props.dispatcher}/>
+    private renderLeafColumns(columns: Column[], key: number): JSX.Element {
+        const ths = columns.map((column: Column, i: number)=> {
+            return (
+                <TableHeaderCell column={column}
+                                 key={i}
+                                 isFirstColumn={i===0}
+                                 isLastColumn={i===columns.length-1}
+                                 columnNumber={i}
+                                 tableHeaderClass={this.props.tableHeaderClass}
+                                 gridProps={this.props.gridProps}
+                                 dispatcher={this.props.dispatcher}
+                />
+            );
         });
         // add a placeholder to offset the scrollbar
-        ths.push(<div className="blank-header-cell text-align-right table-header" key={ths.length} style={{minWidth: '0', width:`${getScrollBarWidth()}px`}}>&nbsp;</div>);
-        if( this.props.staticLeftHeaders > 0 ){
+        ths.push(<div className="blank-header-cell text-align-right table-header" key={ths.length}
+                      style={{minWidth: '0', width:`${getScrollBarWidth()}px`}}>&nbsp;</div>);
+        if (this.props.staticLeftHeaders > 0) {
             const leftHeaders = ths.slice(0, this.props.staticLeftHeaders);
             const rightScrollingHeaders = ths.slice(this.props.staticLeftHeaders);
-            return(
+            return (
                 <div key={key}>
                     <div className="left-static-headers">{leftHeaders}</div>
                     <div className="right-scrolling-headers">{rightScrollingHeaders}</div>

--- a/test/components/Cell.spec.tsx
+++ b/test/components/Cell.spec.tsx
@@ -4,11 +4,10 @@ import {GigaAction} from "../../src/store/GigaStore";
 import {Row} from "../../src/models/Row";
 import {TestUtils} from "../TestUtils";
 import {Column} from "../../src/models/ColumnLike";
-import {Cell, CellProps} from "../../src/components/Cell";
+import {Cell} from "../../src/components/Cell";
 import * as $ from "jquery";
 import {Dispatcher} from "flux";
 
-// TODO re-do!
 describe("Cell", ()=> {
 
     var dispatcher:Dispatcher<GigaAction>;
@@ -25,7 +24,7 @@ describe("Cell", ()=> {
         ReactTestUtils.renderIntoDocument<Cell>(
             <div>
                 <Cell ref={c=>component=c}
-                      rowHeight={""}
+                      rowHeight={"25x"}
                       isFirstColumn={true}
                       dispatcher={dispatcher}
                       column={columns[2]}
@@ -34,54 +33,21 @@ describe("Cell", ()=> {
                 />
             </div>
         );
-        const textContent = ReactTestUtils.scryRenderedDOMComponentsWithClass(component, "content")[0].textContent;
+        let textContent = ReactTestUtils.scryRenderedDOMComponentsWithClass(component, "content")[0].textContent;
         expect(textContent).toBe("R2D2");
-    });
-
-    it("can handle custom cell content", ()=> {
-
-        const colDef = columns[2];
-
-        colDef.cellTemplateCreator = (row:Row, column:Column, props: CellProps):JSX.Element => {
-            return (
-                <div>
-                    <span style={{"color": "green"}}>Hello World</span>
-                </div>
-            )
-        };
-
-        ReactTestUtils.renderIntoDocument<Cell>(
-            <div>
-                <Cell ref={c=>component=c}
-                      isFirstColumn={false}
-                      rowHeight={""}
-                      dispatcher={dispatcher}
-                      column={colDef}
-                      columnNumber={1}
-                      row={row}
-                />
-            </div>
-        );
-
-        const spans = ReactTestUtils.scryRenderedDOMComponentsWithTag(component, "span");
-
-        expect(spans.length).toBe(2);
-        expect(spans[1].textContent).toBe("Hello World");
-        expect($(spans[1]).css("color")).toBe("green");
-
     });
 
     it("can deduce the correct identation for 1st rows in a subtotaled tree", ()=> {
         row.sectorPath = [{colTag: "Level 1", title: "Level 1", value: "Level 1"}, {colTag: "Level 2", title: "Level 2", value: "Level 2"}];
-        const colDef = columns[0];
+        let column = columns[0];
 
         ReactTestUtils.renderIntoDocument(
             <div>
                 <Cell ref={c=>component=c}
-                      rowHeight={""}
+                      rowHeight={"25x"}
                       isFirstColumn={true}
                       dispatcher={dispatcher}
-                      column={colDef}
+                      column={column}
                       columnNumber={1}
                       row={row}
                 />
@@ -91,15 +57,15 @@ describe("Cell", ()=> {
     });
 
     it("can render a +/- for the first cell of a subtotal row", ()=> {
-        const subtotalRow = TestUtils.getSimpleSubtotalRow();
-        const colDef = columns[0];
+        let subtotalRow = TestUtils.getSimpleSubtotalRow();
+        let column = columns[0];
         ReactTestUtils.renderIntoDocument(
             <div>
                 <Cell ref={c=>component=c}
-                      rowHeight={""}
+                      rowHeight={"25x"}
                       isFirstColumn={true}
                       dispatcher={dispatcher}
-                      column={colDef}
+                      column={column}
                       columnNumber={1}
                       row={subtotalRow}/>
             </div>

--- a/test/components/ScrollableGigaRow.spec.tsx
+++ b/test/components/ScrollableGigaRow.spec.tsx
@@ -7,21 +7,24 @@ import * as ReactTestUtils from "react-addons-test-utils";
 import {TestUtils} from "../TestUtils";
 import {Row} from "../../src/models/Row";
 import {Column} from "../../src/models/ColumnLike";
+import {Cell, CellProps} from "../../src/components/Cell";
+import $ = require('jquery');
 
 describe("GigaRow Components", () => {
 
     describe("GigaRow rendering of a SubtotalRow", () => {
         var component = null;
-        const row:Row = TestUtils.getSimpleSubtotalRow();
+        const row: Row = TestUtils.getSimpleSubtotalRow();
         const data = TestUtils.newPeopleTestData();
-        const columns:Column[] = TestUtils.getSimpleColumns();
+        const columns: Column[] = TestUtils.getSimpleColumns();
         ReactTestUtils.renderIntoDocument(
             <div>
-                <ScrollableGigaRow ref={c=>component=c} row={row} rowHeight="25px" columns={columns} dispatcher={null} gridProps={data.gridProps()}/>
+                <ScrollableGigaRow ref={c=>component=c} row={row} rowHeight="25px" columns={columns} dispatcher={null}
+                                   gridProps={data.gridProps()}/>
             </div>
         );
-        const rows:Element[] = ReactTestUtils.scryRenderedDOMComponentsWithClass(component, "giga-grid-row");
-        const singleRow:HTMLDivElement = rows[0] as HTMLDivElement;
+        const rows: Element[] = ReactTestUtils.scryRenderedDOMComponentsWithClass(component, "giga-grid-row");
+        const singleRow: HTMLDivElement = rows[0] as HTMLDivElement;
 
         it("should render a row", () => {
             expect(rows.length).toBe(1);
@@ -40,16 +43,17 @@ describe("GigaRow Components", () => {
 
     describe("GigaRow rendering of a DetailRow", () => {
         var component = null;
-        const row:Row = TestUtils.getDetailRow();
+        const row: Row = TestUtils.getDetailRow();
         const data = TestUtils.newPeopleTestData();
-        const columns:Column[] = TestUtils.getSimpleColumns();
+        const columns: Column[] = TestUtils.getSimpleColumns();
         ReactTestUtils.renderIntoDocument(
             <div>
-                <ScrollableGigaRow ref={c=>component=c} row={row} rowHeight="25px" columns={columns}  dispatcher={null} gridProps={data.gridProps()}/>
+                <ScrollableGigaRow ref={c=>component=c} row={row} rowHeight="25px" columns={columns} dispatcher={null}
+                                   gridProps={data.gridProps()}/>
             </div>
         );
-        const rows:Element[] = ReactTestUtils.scryRenderedDOMComponentsWithClass(component, "giga-grid-row");
-        const singleRow:HTMLDivElement = rows[0] as HTMLDivElement;
+        const rows: Element[] = ReactTestUtils.scryRenderedDOMComponentsWithClass(component, "giga-grid-row");
+        const singleRow: HTMLDivElement = rows[0] as HTMLDivElement;
 
         it("should render a row", () => {
             expect(rows.length).toBe(1);
@@ -62,5 +66,48 @@ describe("GigaRow Components", () => {
             expect(singleRow.className).not.toContain("subtotal-row");
         });
     });
+
+    describe("GigaRow render rows with custom cells instead of the default one", () => {
+        it("can handle custom cell content", ()=> {
+            var component = null;
+            const row: Row = TestUtils.getDetailRow();
+            const column: Column = TestUtils.getSimpleColumns()[0];
+            const data = TestUtils.newPeopleTestData();
+
+            class CustomCell extends Cell {
+                render() {
+                    return super.renderContentContainerWithElement(
+                        <div>
+                            <span style={{color:"green"}}>Hello World</span>
+                        </div>
+                    );
+                }
+            }
+
+            column.cellTemplateCreator = (row: Row, column: Column, props: CellProps) => {
+                return (<CustomCell {...props}/>);
+            };
+
+            ReactTestUtils.renderIntoDocument<Cell>(
+                <div>
+                    <ScrollableGigaRow
+                        ref={c=>component=c}
+                        columns={[column]}
+                        rowHeight={"25px"}
+                        dispatcher={null}
+                        row={row}
+                        gridProps={data.gridProps()}
+                    />
+                </div>
+            );
+
+            const spans = ReactTestUtils.scryRenderedDOMComponentsWithTag(component, "span");
+
+            expect(spans.length).toBe(1);
+            expect(spans[0].textContent).toBe("Hello World");
+            expect($(spans[0]).css("color")).toBe("green");
+
+        });
+    })
 
 });


### PR DESCRIPTION
@caguthrie I changed the way custom cells are rendered, the approach now is to define a class that extends the `Cell` class

The Cell class provide methods to build the wrappers of any cell (including the necessary wrapper `div` and class names)

please review and merge

**Example**:

``` typescript
 class CustomCell extends Cell {
                render() {
                    return super.renderContentContainerWithElement(
                        <div>
                            <span style={{color:"green"}}>Hello World</span>
                        </div>
                    );
                }
            }
```
